### PR TITLE
Feat/Backend - 회원 및 일기 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/af
+/test
+/etc
+poetry.lock
+pyproject.toml
+.env
+__pycache__
+/logs

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1,0 +1,134 @@
+from fastapi import Depends, APIRouter, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import Session, select, exists
+import requests
+from starlette.responses import JSONResponse
+
+from schemas.user import UserSignupDTO
+from schemas.auth import SocialLoginDTO, JwToken
+from models.user import Users
+from models.score import Scores
+from core.config import config
+from core.database import get_session
+from core.security import create_access_token, pwd_context, generate_random_password
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/check-username", status_code=status.HTTP_200_OK)
+def check_username(username: str, session: Session = Depends(get_session)):
+    # 1. username 중복 여부 확인
+    statement = select(exists().where(Users.username == username))
+    result = session.exec(statement).first()
+
+    #  1.1. username 중복 시 false
+    if result:
+        return {"is_available": False}
+    #  1.2. username 중복 아닐 시 true
+    return {"is_available": True}
+
+
+@router.post("/signup", status_code=status.HTTP_201_CREATED)
+def signup(new_user: UserSignupDTO, session: Session = Depends(get_session)):
+    # 1. username 중복 여부 확인
+    statement = select(exists().where(Users.username == new_user.username))
+    result = session.exec(statement).first()
+
+    #  1.1. username 중복 시 예외 처리
+    if result:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Username already exists."
+        )
+
+    # 2.1. user 등록
+    user = Users(
+        username=new_user.username,
+        name=new_user.name,
+        password=pwd_context.hash(new_user.password),
+    )
+    session.add(user)
+    session.flush()  # user_id 할당
+
+    # 2.2. score 등록
+    score = Scores(user_id=user.user_id, level=new_user.level)
+    session.add(score)
+    session.commit()
+
+    return {"message": "User created successfully"}
+
+
+@router.post("/login", response_model=JwToken, status_code=status.HTTP_200_OK)
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    session: Session = Depends(get_session),
+) -> JwToken:
+
+    # 1. username 존재 여부 확인
+    statement = select(Users).where(Users.username == form_data.username)
+    user = session.exec(statement).first()
+
+    #  1.1. username 존재하지 않을 시 예외 처리
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User doesn't exist"
+        )
+
+    # 1.2. password가 다를 경우 예외 처리
+    if not pwd_context.verify(form_data.password, user.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Password mismatch"
+        )
+
+    access_token = create_access_token(data={"sub": str(user.user_id)})
+    return JwToken(access_token=access_token, token_type="bearer")
+
+
+@router.post(path="/naver-login", description="naver social signup/login")
+async def naver_login(form: SocialLoginDTO, session: Session = Depends(get_session)):
+    try:
+        # 1. naver에 access token 요청
+        token_url = f"https://nid.naver.com/oauth2.0/token?client_id={config.naver_client_id}&client_secret={config.naver_secret}&code={form.code}&grant_type=authorization_code&state=test111state"
+        token_response = requests.post(token_url)
+        if token_response.status_code != 200:
+            raise Exception
+
+        # 2. naver에 회원 정보 요청
+        access_token = token_response.json()["access_token"]
+        user_info = f"https://openapi.naver.com/v1/nid/me"
+        headers = {"Authorization": "Bearer " + access_token}
+        user_response = requests.post(user_info, headers=headers)
+        if user_response.status_code != 200:
+            raise Exception
+    except:
+        raise Exception("naver oauth error")
+
+    info = user_response.json()["response"]
+    name = info.get("name")
+    email = info.get("email")
+
+    statement = select(Users).where(Users.username == email)
+    user = session.exec(statement).first()
+
+    # email 없을 시 회원가입 처리 진행
+    if not user:
+        # 3.1. user 등록
+        user = Users(
+            username=email,
+            name=name,
+            password=pwd_context.hash(generate_random_password()),
+        )
+        session.add(user)
+        session.flush()  # user_id 할당
+
+        # 3.2. score 등록
+        score = Scores(user_id=user.user_id, level=form.level)
+        session.add(score)
+        session.commit()
+
+    # 4. JwToken 반환
+    access_token = create_access_token(data={"sub": user.user_id})
+    # return JwToken(access_token=access_token, token_type="bearer")
+
+    response_body = {"message": "oauth register successful", "name": user.username}
+    return JSONResponse(status_code=status.HTTP_200_OK, content=response_body)

--- a/backend/api/routes/diary.py
+++ b/backend/api/routes/diary.py
@@ -1,0 +1,194 @@
+from fastapi import Depends, APIRouter, HTTPException, status
+from sqlmodel import Session, select
+from sqlalchemy import desc, cast, Date
+from typing import List
+from datetime import date
+
+from schemas.diary import DiaryDTO, DiaryExtendedDTO, DiaryBookmarkDTO, DiaryDayDTO
+from models.diary import Diaries
+from core.database import get_session
+from core.security import validate_access_token, oauth2_scheme
+
+
+router = APIRouter(prefix="/diary", tags=["diary"])
+
+
+@router.get(
+    "/date/{date}", response_model=DiaryExtendedDTO, status_code=status.HTTP_200_OK
+)
+def fetch_diary_by_date(
+    date: date,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증 (username이 존재하는지 확인해야 한다. 회원탈퇴했을 수 있으니, 물론 회원탈퇴 가능은 없지만)
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. diary 찾기
+    statement = select(Diaries).where(
+        Diaries.user_id == user_id, cast(Diaries.created_at, Date) == date
+    )
+    diary = session.exec(statement).first()
+
+    # 2.1. diary가 존재하지 않을 시 예외 처리
+    if not diary:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="diary doesn't exist"
+        )
+
+    return DiaryExtendedDTO(
+        diary_id=diary.diary_id,
+        text=diary.text,
+        feedback=diary.feedback,
+        review=diary.review,
+        created_at=diary.created_at,
+    )
+
+
+@router.get(
+    "/page/{page_num}", response_model=List[DiaryDayDTO], status_code=status.HTTP_200_OK
+)
+def fetch_diary_by_page(
+    page_num: int,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. diary created_at 기준으로 정렬 후, n*10 ~ (n+1)*10 일기 뽑기
+    statement = (
+        select(Diaries)
+        .where(Diaries.user_id == user_id)
+        .order_by(desc(Diaries.created_at))
+        .offset(page_num * 10)
+        .limit(10)
+    )
+    diary_list = session.exec(statement).all()
+
+    return [
+        DiaryDayDTO(diary_id=diary.diary_id, day=diary.created_at, status=diary.status)
+        for diary in diary_list
+    ]
+
+
+@router.patch("/bookmark", status_code=status.HTTP_200_OK)
+def bookmark(
+    bookmark: DiaryBookmarkDTO,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. diary 정보 추출
+    diary = session.get(Diaries, bookmark.diary_id)
+    # 2.1. user가 존재하지 않을 시 예외 처리
+    if not diary:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="diary doesn't exist"
+        )
+
+    diary.bookmark = bookmark.bookmark
+    session.commit()
+
+    return {
+        "message": "Diary bookmark successfully changed",
+        "diary_id": diary.diary_id,
+    }
+
+
+@router.get(
+    "/bookmark-page/{page_num}",
+    response_model=List[DiaryDayDTO],
+    status_code=status.HTTP_200_OK,
+)
+def fetch_diary_by_page(
+    page_num: int,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. bookmark diary를 created_at 기준으로 정렬 후, n*10 ~ (n+1)*10 일기 뽑기
+    statement = (
+        select(Diaries)
+        .where(Diaries.user_id == user_id, Diaries.bookmark == True)
+        .order_by(desc(Diaries.created_at))
+        .offset(page_num * 10)
+        .limit(10)
+    )
+    diary_list = session.exec(statement).all()
+
+    return [
+        DiaryDayDTO(diary_id=diary.diary_id, day=diary.created_at, status=diary.status)
+        for diary in diary_list
+    ]
+
+
+@router.post("/feedback", status_code=status.HTTP_202_ACCEPTED)
+def feedback(
+    new_diary: DiaryDTO,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. diary 찾기
+    statement = select(Diaries).where(
+        Diaries.user_id == user_id, Diaries.created_at == date.today()
+    )
+    diary = session.exec(statement).first()
+
+    # 2.1. diary가 존재하지 않을 시 새로 생성
+    if not diary:
+        diary = Diaries(
+            user_id=user_id, text=new_diary.text, status=True, bookmark=False
+        )
+        session.add(diary)
+        session.commit()
+    # 2.2. diary가 존재할 시 수정
+    else:
+        diary.text = new_diary.text
+        diary.status = True
+        session.commit()
+
+    return {
+        "message": "Diary successfully accepted",
+        "diary_id": diary.diary_id,
+    }
+
+
+@router.post("/save", status_code=status.HTTP_202_ACCEPTED)
+def save(
+    new_diary: DiaryDTO,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. diary 찾기
+    statement = select(Diaries).where(
+        Diaries.user_id == user_id, Diaries.created_at == date.today()
+    )
+    diary = session.exec(statement).first()
+
+    # 2.1. diary가 존재하지 않을 시 새로 생성
+    if not diary:
+        diary = Diaries(
+            user_id=user_id, text=new_diary.text, status=False, bookmark=False
+        )
+        session.add(diary)
+        session.commit()
+    # 2.2. diary가 존재할 시 수정
+    else:
+        diary.text = new_diary.text
+        session.commit()
+
+    return {
+        "message": "Diary successfully saved",
+        "diary_id": diary.diary_id,
+    }

--- a/backend/api/routes/user.py
+++ b/backend/api/routes/user.py
@@ -1,0 +1,117 @@
+from fastapi import Depends, APIRouter, HTTPException, status
+from sqlmodel import Session, select
+from datetime import datetime, timedelta
+from calendar import monthrange
+
+from schemas.user import UserDetailDTO, MonthStreakDTO, UserUpdateDTO
+from models.user import Users
+from models.score import Scores
+from core.database import get_session
+from core.security import validate_access_token, oauth2_scheme, pwd_context
+
+
+router = APIRouter(prefix="/user", tags=["user"])
+
+
+@router.get("/profile", response_model=UserDetailDTO, status_code=status.HTTP_200_OK)
+def profile(
+    token: str = Depends(oauth2_scheme), session: Session = Depends(get_session)
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. 유저 정보 추출
+    user = session.get(Users, user_id)
+    # 2.1. user가 존재하지 않을 시 예외 처리
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="user doesn't exist"
+        )
+
+    statement = select(Scores).where(Scores.user_id == user.user_id)
+    score = session.exec(statement).first()
+    return UserDetailDTO(
+        username=user.username,
+        name=user.name,
+        password=user.password,
+        alarm_time=user.alarm_time,
+        tier=score.tier,
+        rating=score.rating,
+        text_cnt=score.text_cnt,
+        vocab_cnt=score.vocab_cnt,
+        diary_cnt=score.diary_cnt,
+    )
+
+
+@router.get("/streak", response_model=MonthStreakDTO, status_code=status.HTTP_200_OK)
+def fetch_streak_by_month(
+    year: int,
+    month: int,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2.1. 시작, 마지막 일자 계산
+    today = datetime.now().date()
+    start_date = today - timedelta(days=364)
+
+    # 2.2. 해당 년/월 시작, 마지막 일자 조회
+    first_day_of_month = datetime(year, month, 1).date()
+    days_in_month = monthrange(year, month)[1]
+    last_day_of_month = datetime(year, month, days_in_month).date()
+
+    # 범위를 벗어나는 경우 조정
+    if first_day_of_month < start_date:
+        days_in_month -= (start_date - first_day_of_month).days
+        first_day_of_month = start_date
+    if last_day_of_month > today:
+        days_in_month -= (last_day_of_month - today).days
+        last_day_of_month = today
+
+    # 인덱스 계산
+    start_index = (today - last_day_of_month).days
+    end_index = start_index + days_in_month
+
+    # score 조회
+    first_day_of_month = datetime(year, month, 1).date()
+    statement = select(Scores).where(Scores.user_id == user_id)
+    score = session.exec(statement).first()
+
+    # month streak 추출
+    streak = []
+    for idx, ele in enumerate(score.streak[start_index:end_index]):
+        if ele > 0:
+            streak.append(first_day_of_month + timedelta(idx))
+
+    return MonthStreakDTO(streak=streak)
+
+
+@router.put("/edit", response_model=UserUpdateDTO, status_code=status.HTTP_200_OK)
+def edit(
+    updated_user: UserUpdateDTO,
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+):
+    # 1. 토큰 검증
+    user_id = validate_access_token(token)["sub"]
+
+    # 2. 유저 정보 추출
+    statement = select(Users).where(Users.user_id == user_id)
+    user = session.exec(statement).first()
+    # 2.1. user가 존재하지 않을 시 예외 처리
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="user doesn't exist"
+        )
+
+    if updated_user.password:
+        user.password = pwd_context.hash(updated_user.password)
+    if updated_user.alarm_time:
+        user.alarm_time = updated_user.alarm_time
+
+    session.commit()
+    session.refresh(user)
+
+    return UserUpdateDTO(password=None, alarm_time=user.alarm_time)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,0 +1,20 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Config(BaseSettings):
+    db_url: str = Field(env="DB_URL")
+    algorithm: str = Field(env="ALGORITHM")
+    secret_key: str = Field(env="SECRET_KEY")
+    expire_minutes: int = Field(env="EXPIRE_MINUTES")
+    kakao_secret: str = Field(env="KAKAO_SECRET")
+    kakao_client_id: str = Field(env="KAKAO_CLIENT_ID")
+    kakao_callback_uri: str = Field(env="KAKAO_CALLBACK_URI")
+    naver_secret: str = Field(env="NAVER_SECRET")
+    naver_client_id: str = Field(env="NAVER_CLIENT_ID")
+
+    class Config:
+        env_file = ".env"
+
+
+config = Config()

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -1,0 +1,11 @@
+from sqlmodel import create_engine, Session
+
+from core.config import config
+
+
+engine = create_engine(config.db_url)
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta
+from fastapi import HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from passlib.context import CryptContext
+from jose import JWTError, jwt
+import random
+import string
+
+from core.config import config
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
+
+
+def create_access_token(data: dict, expires_delta: timedelta = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=config.expire_minutes)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, config.secret_key, algorithm=config.algorithm)
+
+
+def validate_access_token(token: str):
+    try:
+        return jwt.decode(token, config.secret_key, config.algorithm)
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token"
+        )
+
+
+def generate_random_password(length: int = 12) -> str:
+    """
+    무작위 비밀번호 생성 함수.
+
+    Args:
+        length (int): 비밀번호 길이 (기본값 12)
+
+    Returns:
+        str: 생성된 비밀번호
+    """
+    if length < 8:
+        raise ValueError("비밀번호는 최소 8자 이상이어야 합니다.")
+
+    # 비밀번호 구성 요소
+    lower = string.ascii_lowercase  # 소문자
+    upper = string.ascii_uppercase  # 대문자
+    digits = string.digits  # 숫자
+    special = "!@#$%^&*()-_=+<>?"  # 특수 문자
+
+    # 최소 하나의 각 요소를 보장
+    all_characters = lower + upper + digits + special
+    password = [
+        random.choice(lower),
+        random.choice(upper),
+        random.choice(digits),
+        random.choice(special),
+    ]
+
+    # 나머지 비밀번호를 무작위로 채움
+    password += random.choices(all_characters, k=length - 4)
+
+    # 비밀번호를 섞어서 반환
+    random.shuffle(password)
+    return "".join(password)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI
+from contextlib import asynccontextmanager
+from loguru import logger
+from sqlmodel import SQLModel
+from starlette.middleware.cors import CORSMiddleware
+
+
+from models.user import Users
+from models.score import Scores
+from models.diary import Diaries
+from core.database import engine
+from api.routes.user import router as user_router
+from api.routes.auth import router as auth_router
+from api.routes.diary import router as diary_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Creating database table")
+    SQLModel.metadata.create_all(engine)
+    yield
+
+
+app = FastAPI(lifespan=lifespan, root_path="/api")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(user_router)
+app.include_router(auth_router)
+app.include_router(diary_router)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/models/diary.py
+++ b/backend/models/diary.py
@@ -1,0 +1,34 @@
+from sqlmodel import SQLModel, Field
+from sqlalchemy import Column, TEXT, BOOLEAN, DATE
+from datetime import date
+import uuid
+
+
+"""
+CREATE TABLE  diaries (
+    diary_id SERIAL PRIMARY KEY,               -- 일기 ID
+    user_id INTEGER REFERENCES users(user_id), -- 사용자 ID
+    text TEXT NOT NULL,                        -- 일기
+    feedback TEXT,                             -- 피드백 내용
+    review TEXT,                               -- 리뷰 글
+    status BOOLEAN NOT NULL,                   -- true(제출)/false(저장)
+    bookmark BOOLEAN NOT NULL,                 -- 북마크 여부
+    created_at DATE DEFAULT CURRENT_DATE       -- 날짜
+);
+"""
+
+
+class Diaries(SQLModel, table=True):
+    diary_id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.user_id", nullable=False)
+    text: str = Field(sa_column=Column(TEXT, nullable=False))
+    feedback: str = Field(sa_column=Column(TEXT, nullable=True))
+    review: str = Field(sa_column=Column(TEXT, nullable=True))
+    status: bool = Field(sa_column=Column(BOOLEAN, nullable=False))
+    bookmark: bool = Field(sa_column=Column(BOOLEAN, nullable=False))
+    created_at: date = Field(
+        default_factory=date.today, sa_column=Column(DATE, nullable=False)
+    )
+
+
+# status = 0: 저장, 1: 제출, 2: 피드백

--- a/backend/models/score.py
+++ b/backend/models/score.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from sqlmodel import SQLModel, Field
+from typing import List
+import uuid
+from sqlalchemy import Column, ARRAY, INTEGER, TIMESTAMP
+
+
+"""
+CREATE TABLE scores (
+    score_id SERIAL PRIMARY KEY,                   -- 점수 ID
+    user_id INTEGER REFERENCES users(user_id),     -- 사용자 ID
+    level INTEGER,                                 -- 퀴즈, 설명 난이도
+    tier INTEGER DEFAULT 0,                        -- 등급
+    rating INTEGER DEFAULT 0,                      -- 누적 점수
+    streak INTEGER[365],                           -- 지난 365일 스트릭
+    text_cnt INTEGER DEFAULT 0,                    -- 긴 글 문제 푼 개수
+    vocab_cnt INTEGER DEFAULT 0,                   -- 단어 문제 푼 횟수
+    diary_cnt INTEGER DEFAULT 0,                   -- 일기 작성 횟수
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP -- 최근 수정 시간
+);
+"""
+
+
+class Scores(SQLModel, table=True):
+    score_id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.user_id", nullable=False)
+    level: int = Field(sa_column=Column(INTEGER, nullable=True))
+    tier: int = Field(default=0, sa_column=Column(INTEGER, nullable=False))
+    rating: int = Field(default=0, sa_column=Column(INTEGER, nullable=False))
+    streak: List[int] = Field(
+        default_factory=lambda: [-1] * 365,
+        sa_column=Column(ARRAY(INTEGER), nullable=False),
+    )
+    text_cnt: int = Field(default=0, sa_column=Column(INTEGER, nullable=False))
+    vocab_cnt: int = Field(default=0, sa_column=Column(INTEGER, nullable=False))
+    diary_cnt: int = Field(default=0, sa_column=Column(INTEGER, nullable=False))
+    updated_at: datetime = Field(
+        default_factory=datetime.now, sa_column=Column(TIMESTAMP, nullable=False)
+    )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime, time
+from sqlmodel import SQLModel, Field
+from sqlalchemy import Column, TIME, VARCHAR, TIMESTAMP
+from sqlalchemy.dialects.postgresql import CITEXT
+
+
+"""
+CREATE TABLE users (
+    user_id SERIAL PRIMARY KEY,                         -- 사용자 고유 ID
+    username VARCHAR(255) NOT NULL,                     -- 사용자 닉네임
+    name VARCHAR(255) NOT NULL,                         -- 사용자 이름
+    password VARCHAR(255) NOT NULL,                     -- 비밀번호
+    alarm_time TIME NOT NULL,                           -- 알람 시간
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP      -- 계정 생성 시간
+);
+"""
+
+
+class Users(SQLModel, table=True):
+    user_id: int | None = Field(default=None, primary_key=True)
+    username: str = Field(sa_column=Column(VARCHAR(255), nullable=False))
+    name: str = Field(sa_column=Column(VARCHAR(255), nullable=False))
+    password: str = Field(sa_column=Column(VARCHAR(255), nullable=False))
+    alarm_time: time = Field(
+        default=time(21, 0), sa_column=Column(TIME, nullable=False)
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.now, sa_column=Column(TIMESTAMP, nullable=False)
+    )

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class JwToken(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class SocialLoginDTO(BaseModel):
+    code: str
+    level: int

--- a/backend/schemas/diary.py
+++ b/backend/schemas/diary.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import date
+
+
+class DiaryDTO(BaseModel):
+    text: str
+
+
+class DiaryBookmarkDTO(BaseModel):
+    diary_id: int
+    bookmark: bool
+
+
+class DiaryDayDTO(BaseModel):
+    diary_id: int
+    day: date
+    status: bool
+
+
+class DiaryExtendedDTO(BaseModel):
+    diary_id: int
+    text: str
+    feedback: Optional[str] = None
+    review: Optional[str] = None
+    created_at: date

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel
+from datetime import date
+from typing import List, Optional
+import datetime
+
+
+class UserSignupDTO(BaseModel):
+    username: str
+    name: str
+    password: str
+    level: int
+
+
+class UserUpdateDTO(BaseModel):
+    password: Optional[str] = None
+    alarm_time: Optional[datetime.time] = None
+
+
+class UserDetailDTO(BaseModel):
+    username: str
+    name: str
+    password: str
+    alarm_time: datetime.time
+    tier: int
+    rating: int
+    text_cnt: int
+    vocab_cnt: int
+    diary_cnt: int
+
+
+class MonthStreakDTO(BaseModel):
+    streak: List[date]


### PR DESCRIPTION
## 🪡 Pull Request

### Overview
<!-- 작업에 대한 개요를 간략하게 설명해주세요. -->
Auth, User, Diary와 관련된 API 구현
- Auth: 회원가입, 로그인
- User: 회원 정보 조회, 학습 기록 조회
- Diary: 일기 저장 및 제출, 일기 & 피드백 조회

### Change Log
<!-- 작업에서 변경된 부분을 간략하게 설명해주세요. -->
- `/api/routes` 에 `auth.py`, `user.py`, `diary.py` 파일을 생성하여 각 파일에 **API** 구현
- `/models` 디렉토리에도 `auth.py`, `user.py`, `diary.py` 파일을 생성하여 각 파일에 **DB 엔티티 클래스** 작성
- `/schemas` 디렉토리에도 동일한 구조로 파일을 생성하여 각 파일에 **DTO 클래스** 작성
- `/cores` 디렉토리에는 데이터베이스 연결 설정, 환경 변수 관리, 보안 및 인증 관련 코드를 각각의 파일로 분리 작성

### Issue Tags
<!-- 이 PR과 관련된 이슈를 작성해주세요. -->
- Closed | Fixed: #6 